### PR TITLE
Add OpenAPI documentation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Payments Service
+
+This project provides a simple payments API built with Spring Boot.
+
+## Running the application
+
+```bash
+./mvnw spring-boot:run
+```
+
+The API will be available at `http://localhost:8080`.
+
+## API documentation
+
+Interactive API documentation is provided via SpringDoc OpenAPI. After starting the application, open the Swagger UI at:
+
+- http://localhost:8080/swagger-ui.html
+
+The OpenAPI description can also be obtained in JSON format from `http://localhost:8080/v3/api-docs`.

--- a/pom.xml
+++ b/pom.xml
@@ -29,19 +29,25 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.6.0</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>

--- a/src/main/java/com/example/payments/OpenApiConfig.java
+++ b/src/main/java/com/example/payments/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.example.payments;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI paymentsOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Payments Service API")
+                        .version("1.0.0")
+                        .description("API documentation for processing payments, captures, and refunds."));
+    }
+}

--- a/src/main/java/com/example/payments/controller/PaymentController.java
+++ b/src/main/java/com/example/payments/controller/PaymentController.java
@@ -3,8 +3,18 @@ package com.example.payments.controller;
 import com.example.payments.model.PaymentRequest;
 import com.example.payments.model.RefundRequest;
 import com.example.payments.service.PaymentService;
-import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -16,16 +26,54 @@ public class PaymentController {
         this.service = service;
     }
 
+    @Operation(
+            summary = "Authorize a payment",
+            description = "Authorizes a payment between a buyer and a seller before funds are captured.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "Payment information required to authorize a transaction",
+                    content = @Content(schema = @Schema(implementation = PaymentRequest.class))
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Payment successfully authorized"),
+            @ApiResponse(responseCode = "400", description = "Invalid payment request supplied")
+    })
     @PostMapping("/authorize")
-    public String authorize( @Valid @RequestBody PaymentRequest request) {
+    public String authorize(@Valid @RequestBody PaymentRequest request) {
         return service.authorize(request);
     }
 
+    @Operation(
+            summary = "Capture an authorized payment",
+            description = "Captures funds for a previously authorized transaction."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Payment successfully captured"),
+            @ApiResponse(responseCode = "404", description = "Authorization not found"),
+            @ApiResponse(responseCode = "400", description = "Capture request is invalid")
+    })
     @PostMapping("/capture")
-    public String capture(@RequestParam String authId) {
+    public String capture(
+            @Parameter(description = "Authorization identifier returned from the authorize endpoint", example = "auth_123")
+            @RequestParam String authId) {
         return service.capture(authId);
     }
 
+    @Operation(
+            summary = "Refund a payment",
+            description = "Issues a refund for a captured payment.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "Details of the payment and amount to refund",
+                    content = @Content(schema = @Schema(implementation = RefundRequest.class))
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Refund successfully processed"),
+            @ApiResponse(responseCode = "404", description = "Payment not found"),
+            @ApiResponse(responseCode = "400", description = "Refund request is invalid")
+    })
     @PostMapping("/refund")
     public String refund(@Valid @RequestBody RefundRequest request) {
         return service.refund(request);

--- a/src/main/java/com/example/payments/model/PaymentRequest.java
+++ b/src/main/java/com/example/payments/model/PaymentRequest.java
@@ -1,16 +1,21 @@
 package com.example.payments.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "Payload describing a payment to authorize")
 public class PaymentRequest {
 
+    @Schema(description = "Unique identifier of the buyer initiating the payment", example = "buyer_001")
     @NotBlank(message = "Buyer ID is required")
     public String buyerId;
 
+    @Schema(description = "Unique identifier of the seller receiving the payment", example = "seller_987")
     @NotBlank(message = "Seller ID is required")
     public String sellerId;
 
+    @Schema(description = "Amount of the payment in USD", example = "49.99")
     @Positive(message = "Amount must be greater than zero")
     public double amount;
 }

--- a/src/main/java/com/example/payments/model/RefundRequest.java
+++ b/src/main/java/com/example/payments/model/RefundRequest.java
@@ -1,13 +1,17 @@
 package com.example.payments.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "Payload describing a refund request")
 public class RefundRequest {
 
+    @Schema(description = "Identifier of the payment to refund", example = "pay_456")
     @NotBlank(message = "Payment ID is required")
     public String paymentId;
 
+    @Schema(description = "Amount to refund in USD", example = "25.00")
     @Positive(message = "Refund amount must be greater than zero")
     public double amount;
 }


### PR DESCRIPTION
## Summary
- add the SpringDoc OpenAPI starter dependency and configuration with API metadata
- annotate payment controller endpoints and request models to enrich generated docs
- document Swagger UI access in the README

## Testing
- ./mvnw -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dbfe3d1e5c8325b8cfb0097137f817