### PR TITLE
Add application status controller and tests

### DIFF
--- a/src/main/java/com/example/payments/web/AppStatusController.java
+++ b/src/main/java/com/example/payments/web/AppStatusController.java
@@ -1,0 +1,58 @@
+package com.example.payments.web;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.Objects;
+
+@RestController
+public class AppStatusController implements ErrorController {
+
+    @GetMapping("/")
+    public ResponseEntity<Map<String, String>> root() {
+        Map<String, String> payload = Map.of(
+                "status", "UP",
+                "message", "Payments Service is running"
+        );
+        return ResponseEntity.ok(payload);
+    }
+
+    @RequestMapping("/error")
+    public ResponseEntity<ProblemDetail> handleError(HttpServletRequest request) {
+        HttpStatus status = resolveStatus(request);
+        String detail = Objects.toString(
+                request.getAttribute(RequestDispatcher.ERROR_MESSAGE),
+                status.getReasonPhrase()
+        );
+
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setTitle("Unexpected error");
+        problemDetail.setDetail(detail);
+
+        Object path = request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+        if (path != null) {
+            problemDetail.setProperty("path", path);
+        }
+
+        return ResponseEntity.status(status).body(problemDetail);
+    }
+
+    private HttpStatus resolveStatus(HttpServletRequest request) {
+        Object statusCode = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        if (statusCode instanceof Integer code) {
+            HttpStatus resolved = HttpStatus.resolve(code);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/test/java/com/example/payments/web/AppStatusControllerTest.java
+++ b/src/test/java/com/example/payments/web/AppStatusControllerTest.java
@@ -1,0 +1,43 @@
+package com.example.payments.web;
+
+import jakarta.servlet.RequestDispatcher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AppStatusController.class)
+class AppStatusControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("GET / should return health payload")
+    void rootReturnsHealthPayload() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.message").value("Payments Service is running"));
+    }
+
+    @Test
+    @DisplayName("/error should map request attributes to ProblemDetail")
+    void errorReturnsProblemDetail() throws Exception {
+        mockMvc.perform(get("/error")
+                        .requestAttr(RequestDispatcher.ERROR_STATUS_CODE, HttpStatus.NOT_FOUND.value())
+                        .requestAttr(RequestDispatcher.ERROR_MESSAGE, "Resource not found")
+                        .requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/missing"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("Unexpected error"))
+                .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.detail").value("Resource not found"))
+                .andExpect(jsonPath("$.path").value("/missing"));
+    }
+}


### PR DESCRIPTION
## Summary
- add an application status controller that reports health at the root path
- return structured `ProblemDetail` responses from the `/error` endpoint using servlet attributes
- cover both endpoints with MVC tests to ensure expected payloads and status codes

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68dc4028c7cc8325bdfcf4196dca7ba2