### PR TITLE
Hide error endpoint from OpenAPI spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
                 <dependency>
                         <groupId>org.springdoc</groupId>
                         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-                        <version>2.6.0</version>
+                        <version>2.8.13</version>
                 </dependency>
 
                 <dependency>

--- a/src/main/java/com/example/payments/web/AppStatusController.java
+++ b/src/main/java/com/example/payments/web/AppStatusController.java
@@ -1,5 +1,6 @@
 package com.example.payments.web;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.boot.web.servlet.error.ErrorController;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 import java.util.Objects;
 
+@Hidden
 @RestController
 public class AppStatusController implements ErrorController {
 
@@ -25,6 +27,7 @@ public class AppStatusController implements ErrorController {
         return ResponseEntity.ok(payload);
     }
 
+    @Hidden
     @RequestMapping("/error")
     public ResponseEntity<ProblemDetail> handleError(HttpServletRequest request) {
         HttpStatus status = resolveStatus(request);


### PR DESCRIPTION
## Summary
- hide the error controller from the generated OpenAPI spec so /error is not documented
- bump springdoc-openapi starter to 2.8.13 to stay compatible with Spring Boot 3.5

## Testing
- ./mvnw spring-boot:run
- curl -s http://localhost:8080/v3/api-docs | head

------
https://chatgpt.com/codex/tasks/task_e_68dc45b5827c8325ba20d71b07eb5dbf