### PR TITLE
Expose root status endpoint in OpenAPI

### DIFF
--- a/src/main/java/com/example/payments/web/AppStatusController.java
+++ b/src/main/java/com/example/payments/web/AppStatusController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 import java.util.Objects;
 
-@Hidden
 @RestController
 public class AppStatusController implements ErrorController {
 


### PR DESCRIPTION
## Summary
- remove the class-level Hidden annotation from AppStatusController so the root status endpoint is included in the OpenAPI spec

## Testing
- ./mvnw spring-boot:run
- curl http://localhost:8080/v3/api-docs

------
https://chatgpt.com/codex/tasks/task_e_68dc4cc61b808325ad06ce16d567b792